### PR TITLE
Created queries for both scenic and skyquery

### DIFF
--- a/evaluation/examples/evaluation-queries.ipynb
+++ b/evaluation/examples/evaluation-queries.ipynb
@@ -18,10 +18,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "961762b7-06ea-4cf9-b771-0fcf17f328a1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ImportError",
+     "evalue": "attempted relative import with no known parent package",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[2], line 12\u001b[0m\n\u001b[1;32m     10\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mvideo_processor\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcamera_config\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m camera_config\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mutils\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mF\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m distance, contains, heading_diff, has_types, stopped, left_turn\n\u001b[0;32m---> 12\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mutils\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m topdown_config, vv_config, resize\n",
+      "File \u001b[0;32m~/spatialyze/evaluation/examples/utils.py:6\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mtyping\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m NamedTuple\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mnumpy\u001b[39;00m \u001b[38;5;28;01mas\u001b[39;00m \u001b[38;5;21;01mnp\u001b[39;00m\n\u001b[0;32m----> 6\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mtypes\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m Float2, Float3, Float33\n\u001b[1;32m      9\u001b[0m start_date \u001b[38;5;241m=\u001b[39m datetime\u001b[38;5;241m.\u001b[39mdatetime(\n\u001b[1;32m     10\u001b[0m     year\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m2018\u001b[39m,\n\u001b[1;32m     11\u001b[0m     month\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m8\u001b[39m,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     16\u001b[0m     microsecond\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m0\u001b[39m\n\u001b[1;32m     17\u001b[0m )\n\u001b[1;32m     20\u001b[0m \u001b[38;5;66;03m# SkyQuery ---\u001b[39;00m\n",
+      "\u001b[0;31mImportError\u001b[0m: attempted relative import with no known parent package"
+     ]
+    }
+   ],
    "source": [
     "import pickle\n",
     "import os\n",
@@ -33,7 +46,7 @@
     "from spatialyze.road_network import RoadNetwork\n",
     "from spatialyze.world import World\n",
     "from spatialyze.video_processor.camera_config import camera_config\n",
-    "from spatialyze.utils.F import distance, contains, heading_diff, has_types, stopped, turn_left\n",
+    "from spatialyze.utils.F import distance, contains, heading_diff, has_types, stopped, left_turn\n",
     "from utils import topdown_config, vv_config, resize"
    ]
   },
@@ -47,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "2c7e8662-6d2c-4933-944a-6fa5a975c63c",
    "metadata": {},
    "outputs": [],
@@ -75,7 +88,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "3e412c3c-2219-4cfb-b510-71ce5dbf90f9",
    "metadata": {},
    "outputs": [],
@@ -100,10 +113,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "dc044ce5-0a1f-4008-9fe6-38fee87ac268",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<spatialyze.world.World at 0x16c75e7d0>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "world = World()\n",
     "world.addGeogConstructs(RoadNetwork('Boston-Seaport', ROAD_DIR))\n",
@@ -132,10 +156,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "0f1ce3e9-0a62-4de2-9f91-28aade895e0a",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "CallNode(_fn=(<function road_segment at 0x119201b40>,), params=[LiteralNode(value='intersection', python=True)])",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[6], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mworld\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msaveVideos\u001b[49m\u001b[43m(\u001b[49m\u001b[43mos\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpath\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mjoin\u001b[49m\u001b[43m(\u001b[49m\u001b[43mOUTPUT_DIR\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mq1\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maddBoundingBoxes\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:108\u001b[0m, in \u001b[0;36mWorld.saveVideos\u001b[0;34m(self, outputDir, addBoundingBoxes)\u001b[0m\n\u001b[1;32m    106\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msaveVideos\u001b[39m(\u001b[38;5;28mself\u001b[39m, outputDir: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstr\u001b[39m\u001b[38;5;124m\"\u001b[39m, addBoundingBoxes: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbool\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m):\n\u001b[1;32m    107\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 108\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;241m=\u001b[39m \u001b[43m_execute\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m    109\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m save_video_util(\n\u001b[1;32m    110\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects,\n\u001b[1;32m    111\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings,\n\u001b[1;32m    112\u001b[0m         outputDir,\n\u001b[1;32m    113\u001b[0m         addBoundingBoxes,\n\u001b[1;32m    114\u001b[0m     )\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:161\u001b[0m, in \u001b[0;36m_execute\u001b[0;34m(world, optimization)\u001b[0m\n\u001b[1;32m    159\u001b[0m     decode \u001b[38;5;241m=\u001b[39m PruneFrames(prefilter, decode)\n\u001b[1;32m    160\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m optimization:\n\u001b[0;32m--> 161\u001b[0m     inview \u001b[38;5;241m=\u001b[39m \u001b[43mRoadVisibilityPruner\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdistance\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m50\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredicate\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mworld\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpredicates\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    162\u001b[0m     decode \u001b[38;5;241m=\u001b[39m PruneFrames(inview, decode)\n\u001b[1;32m    163\u001b[0m d2ds \u001b[38;5;241m=\u001b[39m detector(decode)\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stream/road_visibility_pruner.py:17\u001b[0m, in \u001b[0;36mRoadVisibilityPruner.__init__\u001b[0;34m(self, distance, roadtypes, predicate)\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\n\u001b[1;32m     12\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m     13\u001b[0m     distance: \u001b[38;5;28mfloat\u001b[39m,\n\u001b[1;32m     14\u001b[0m     roadtypes: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m|\u001b[39m \u001b[38;5;28mlist\u001b[39m[\u001b[38;5;28mstr\u001b[39m] \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     15\u001b[0m     predicate: PredicateNode \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     16\u001b[0m ):\n\u001b[0;32m---> 17\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39minview \u001b[38;5;241m=\u001b[39m \u001b[43mInView\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdistance\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mroadtypes\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredicate\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:61\u001b[0m, in \u001b[0;36mInView.__init__\u001b[0;34m(self, distance, roadtypes, predicate)\u001b[0m\n\u001b[1;32m     59\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m predicate \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m     60\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m roadtypes \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mCan only except either segment_type or predicate\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 61\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mroadtypes, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate_str \u001b[38;5;241m=\u001b[39m \u001b[43mcreate_inview_predicate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpredicate\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     62\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate \u001b[38;5;241m=\u001b[39m \u001b[38;5;28meval\u001b[39m(\u001b[38;5;28mstr\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate_str))\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:599\u001b[0m, in \u001b[0;36mcreate_inview_predicate\u001b[0;34m(node)\u001b[0m\n\u001b[1;32m    596\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mcreate_inview_predicate\u001b[39m(\n\u001b[1;32m    597\u001b[0m     node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mPredicateNode\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m    598\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtuple[list[str], str | bool]\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m--> 599\u001b[0m     node \u001b[38;5;241m=\u001b[39m \u001b[43mKeepOnlyRoadTypePredicates\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    600\u001b[0m     \u001b[38;5;66;03m# Note True/False will either disappear from all the predicates or propagate to the top\u001b[39;00m\n\u001b[1;32m    601\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node, LiteralNode):\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:245\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    244\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: BoolOpNode):\n\u001b[0;32m--> 245\u001b[0m     visited \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvisit_BoolOpNode\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    246\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(visited, BoolOpNode), visited\n\u001b[1;32m    247\u001b[0m     annihilator \u001b[38;5;241m=\u001b[39m ANNIHILATORS[node\u001b[38;5;241m.\u001b[39mop]\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36mBaseTransformer.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28mself\u001b[39m(e) \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43me\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:292\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_CallNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    289\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m node\u001b[38;5;241m.\u001b[39mfn \u001b[38;5;241m==\u001b[39m F\u001b[38;5;241m.\u001b[39mcontains()\u001b[38;5;241m.\u001b[39mfn:\n\u001b[1;32m    290\u001b[0m     \u001b[38;5;66;03m# print('contains')\u001b[39;00m\n\u001b[1;32m    291\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams) \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m2\u001b[39m\n\u001b[0;32m--> 292\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m], LiteralNode), node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    293\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\u001b[38;5;241m.\u001b[39mvalue, \u001b[38;5;28mstr\u001b[39m), node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    294\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m F\u001b[38;5;241m.\u001b[39mis_roadtype(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m])\n",
+      "\u001b[0;31mAssertionError\u001b[0m: CallNode(_fn=(<function road_segment at 0x119201b40>,), params=[LiteralNode(value='intersection', python=True)])"
+     ]
+    }
+   ],
    "source": [
     "world.saveVideos(os.path.join(OUTPUT_DIR, 'q1'), addBoundingBoxes=True)"
    ]
@@ -150,10 +197,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "c8ae51e4-b5da-4791-83ef-c8320050bbc0",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<spatialyze.world.World at 0x16e285d80>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "world = World()\n",
     "world.addGeogConstructs(RoadNetwork('Boston-Seaport', ROAD_DIR))\n",

--- a/evaluation/examples/example-query.ipynb
+++ b/evaluation/examples/example-query.ipynb
@@ -158,7 +158,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.13"
   },
   "vscode": {
    "interpreter": {

--- a/evaluation/examples/ianhdong/scenic-figure12.ipynb
+++ b/evaluation/examples/ianhdong/scenic-figure12.ipynb
@@ -1,0 +1,181 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b5324e5c-aabc-42d9-94cb-3dffae501e4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from os import environ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "fbb7ced7-6d62-42ef-a839-8391c0c64e22",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'utils'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[11], line 12\u001b[0m\n\u001b[1;32m     10\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mvideo_processor\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcamera_config\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m camera_config\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mutils\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mF\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m distance, contains, heading_diff, has_types, stopped, left_turn, view_angle\n\u001b[0;32m---> 12\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mutils\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m topdown_config, vv_config, resize\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'utils'"
+     ]
+    }
+   ],
+   "source": [
+    "import pickle\n",
+    "import os\n",
+    "import json\n",
+    "\n",
+    "import cv2\n",
+    "\n",
+    "from spatialyze.geospatial_video import GeospatialVideo\n",
+    "from spatialyze.road_network import RoadNetwork\n",
+    "from spatialyze.world import World\n",
+    "from spatialyze.video_processor.camera_config import camera_config\n",
+    "from spatialyze.utils.F import distance, contains, heading_diff, has_types, stopped, left_turn, view_angle\n",
+    "from utils import topdown_config, vv_config, resize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "69551780-c87e-4c9c-9462-1906cc77bb33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_DIR = '../../../data'\n",
+    "OUTPUT_DIR = os.path.join(DATA_DIR, 'pipeline/outputs')\n",
+    "VIDEO_DIR = os.path.join(DATA_DIR, 'pipeline/videos')\n",
+    "ROAD_DIR = os.path.join(DATA_DIR, 'scenic/road-network/boston-seaport')\n",
+    "\n",
+    "files = os.listdir(VIDEO_DIR)\n",
+    "with open(os.path.join(VIDEO_DIR, 'frames.pkl'), 'rb') as f:\n",
+    "    videos = pickle.load(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "dfdda3e8-1a07-4a19-b3ee-db97e71a38a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<spatialyze.world.World at 0x285e2be50>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "world = World()\n",
+    "world.addGeogConstructs(RoadNetwork('Boston-Seaport', ROAD_DIR))\n",
+    "\n",
+    "for file in os.listdir(VIDEO_DIR):\n",
+    "    if not file.endswith('.camera.pkl'):\n",
+    "        continue\n",
+    "\n",
+    "    with open(os.path.join(VIDEO_DIR, file), 'rb') as f:\n",
+    "        camera = pickle.load(f)\n",
+    "    videofile = os.path.join(VIDEO_DIR, camera['filename'])\n",
+    "    camera = [camera_config(*c) for c in camera['frames']]\n",
+    "\n",
+    "    world.addVideo(GeospatialVideo(videofile, camera))\n",
+    "\n",
+    "car = world.object()\n",
+    "pedestrian = world.object()\n",
+    "camera = world.camera()\n",
+    "intersection = world.geogConstruct(type='intersection')\n",
+    "road = world.geogConstruct(type='road')\n",
+    "\n",
+    "world.filter(\n",
+    "    has_types(car, 'car') &\n",
+    "    (distance(camera, car) < 50) &\n",
+    "    (view_angle(camera, car) < 135) &\n",
+    "    has_types(pedestrian, 'pedestrian') &\n",
+    "    heading_diff(camera, pedestrian, between=[-180, 180]) & \n",
+    "    (contains(intersection, [car, pedestrian]) |\n",
+    "        contains(road, [car, pedestrian])) &\n",
+    "    ~heading_diff(road, car, between=[-70, 70])\n",
+    ")\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "a5cc61d2-35db-4349-997c-9f64d06fad21",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "CallNode(_fn=(<function road_segment at 0x107d01cf0>,), params=[LiteralNode(value='intersection', python=True)])",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[15], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mworld\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msaveVideos\u001b[49m\u001b[43m(\u001b[49m\u001b[43mos\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpath\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mjoin\u001b[49m\u001b[43m(\u001b[49m\u001b[43mOUTPUT_DIR\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mfigure12\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maddBoundingBoxes\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:108\u001b[0m, in \u001b[0;36mWorld.saveVideos\u001b[0;34m(self, outputDir, addBoundingBoxes)\u001b[0m\n\u001b[1;32m    106\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msaveVideos\u001b[39m(\u001b[38;5;28mself\u001b[39m, outputDir: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstr\u001b[39m\u001b[38;5;124m\"\u001b[39m, addBoundingBoxes: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbool\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m):\n\u001b[1;32m    107\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 108\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;241m=\u001b[39m \u001b[43m_execute\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m    109\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m save_video_util(\n\u001b[1;32m    110\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects,\n\u001b[1;32m    111\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings,\n\u001b[1;32m    112\u001b[0m         outputDir,\n\u001b[1;32m    113\u001b[0m         addBoundingBoxes,\n\u001b[1;32m    114\u001b[0m     )\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:161\u001b[0m, in \u001b[0;36m_execute\u001b[0;34m(world, optimization)\u001b[0m\n\u001b[1;32m    159\u001b[0m     decode \u001b[38;5;241m=\u001b[39m PruneFrames(prefilter, decode)\n\u001b[1;32m    160\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m optimization:\n\u001b[0;32m--> 161\u001b[0m     inview \u001b[38;5;241m=\u001b[39m \u001b[43mRoadVisibilityPruner\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdistance\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m50\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredicate\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mworld\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpredicates\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    162\u001b[0m     decode \u001b[38;5;241m=\u001b[39m PruneFrames(inview, decode)\n\u001b[1;32m    163\u001b[0m d2ds \u001b[38;5;241m=\u001b[39m detector(decode)\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stream/road_visibility_pruner.py:17\u001b[0m, in \u001b[0;36mRoadVisibilityPruner.__init__\u001b[0;34m(self, distance, roadtypes, predicate)\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\n\u001b[1;32m     12\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m     13\u001b[0m     distance: \u001b[38;5;28mfloat\u001b[39m,\n\u001b[1;32m     14\u001b[0m     roadtypes: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m|\u001b[39m \u001b[38;5;28mlist\u001b[39m[\u001b[38;5;28mstr\u001b[39m] \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     15\u001b[0m     predicate: PredicateNode \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     16\u001b[0m ):\n\u001b[0;32m---> 17\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39minview \u001b[38;5;241m=\u001b[39m \u001b[43mInView\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdistance\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mroadtypes\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredicate\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:61\u001b[0m, in \u001b[0;36mInView.__init__\u001b[0;34m(self, distance, roadtypes, predicate)\u001b[0m\n\u001b[1;32m     59\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m predicate \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m     60\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m roadtypes \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mCan only except either segment_type or predicate\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 61\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mroadtypes, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate_str \u001b[38;5;241m=\u001b[39m \u001b[43mcreate_inview_predicate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpredicate\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     62\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate \u001b[38;5;241m=\u001b[39m \u001b[38;5;28meval\u001b[39m(\u001b[38;5;28mstr\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate_str))\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:599\u001b[0m, in \u001b[0;36mcreate_inview_predicate\u001b[0;34m(node)\u001b[0m\n\u001b[1;32m    596\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mcreate_inview_predicate\u001b[39m(\n\u001b[1;32m    597\u001b[0m     node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mPredicateNode\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m    598\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtuple[list[str], str | bool]\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m--> 599\u001b[0m     node \u001b[38;5;241m=\u001b[39m \u001b[43mKeepOnlyRoadTypePredicates\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    600\u001b[0m     \u001b[38;5;66;03m# Note True/False will either disappear from all the predicates or propagate to the top\u001b[39;00m\n\u001b[1;32m    601\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node, LiteralNode):\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:245\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    244\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: BoolOpNode):\n\u001b[0;32m--> 245\u001b[0m     visited \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvisit_BoolOpNode\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    246\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(visited, BoolOpNode), visited\n\u001b[1;32m    247\u001b[0m     annihilator \u001b[38;5;241m=\u001b[39m ANNIHILATORS[node\u001b[38;5;241m.\u001b[39mop]\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36mBaseTransformer.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28mself\u001b[39m(e) \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43me\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:245\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    244\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: BoolOpNode):\n\u001b[0;32m--> 245\u001b[0m     visited \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvisit_BoolOpNode\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    246\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(visited, BoolOpNode), visited\n\u001b[1;32m    247\u001b[0m     annihilator \u001b[38;5;241m=\u001b[39m ANNIHILATORS[node\u001b[38;5;241m.\u001b[39mop]\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36mBaseTransformer.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28mself\u001b[39m(e) \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43me\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:292\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_CallNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    289\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m node\u001b[38;5;241m.\u001b[39mfn \u001b[38;5;241m==\u001b[39m F\u001b[38;5;241m.\u001b[39mcontains()\u001b[38;5;241m.\u001b[39mfn:\n\u001b[1;32m    290\u001b[0m     \u001b[38;5;66;03m# print('contains')\u001b[39;00m\n\u001b[1;32m    291\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams) \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m2\u001b[39m\n\u001b[0;32m--> 292\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m], LiteralNode), node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    293\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\u001b[38;5;241m.\u001b[39mvalue, \u001b[38;5;28mstr\u001b[39m), node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    294\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m F\u001b[38;5;241m.\u001b[39mis_roadtype(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m])\n",
+      "\u001b[0;31mAssertionError\u001b[0m: CallNode(_fn=(<function road_segment at 0x107d01cf0>,), params=[LiteralNode(value='intersection', python=True)])"
+     ]
+    }
+   ],
+   "source": [
+    "world.saveVideos(os.path.join(OUTPUT_DIR, 'figure12'), addBoundingBoxes=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "affbc518-8948-469a-9e40-08fce69e4161",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/evaluation/examples/ianhdong/scenic-figure13.ipynb
+++ b/evaluation/examples/ianhdong/scenic-figure13.ipynb
@@ -1,0 +1,180 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b5324e5c-aabc-42d9-94cb-3dffae501e4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from os import environ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fbb7ced7-6d62-42ef-a839-8391c0c64e22",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CUDA is not available.\n"
+     ]
+    },
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'utils'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[2], line 12\u001b[0m\n\u001b[1;32m     10\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mvideo_processor\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcamera_config\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m camera_config\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mutils\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mF\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m distance, contains, heading_diff, has_types, stopped, left_turn, view_angle\n\u001b[0;32m---> 12\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mutils\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m topdown_config, vv_config, resize\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'utils'"
+     ]
+    }
+   ],
+   "source": [
+    "import pickle\n",
+    "import os\n",
+    "import json\n",
+    "\n",
+    "import cv2\n",
+    "\n",
+    "from spatialyze.geospatial_video import GeospatialVideo\n",
+    "from spatialyze.road_network import RoadNetwork\n",
+    "from spatialyze.world import World\n",
+    "from spatialyze.video_processor.camera_config import camera_config\n",
+    "from spatialyze.utils.F import distance, contains, heading_diff, has_types, stopped, left_turn, view_angle\n",
+    "from utils import topdown_config, vv_config, resize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "69551780-c87e-4c9c-9462-1906cc77bb33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_DIR = '../../../data'\n",
+    "OUTPUT_DIR = os.path.join(DATA_DIR, 'pipeline/outputs')\n",
+    "VIDEO_DIR = os.path.join(DATA_DIR, 'pipeline/videos')\n",
+    "ROAD_DIR = os.path.join(DATA_DIR, 'scenic/road-network/boston-seaport')\n",
+    "\n",
+    "files = os.listdir(VIDEO_DIR)\n",
+    "with open(os.path.join(VIDEO_DIR, 'frames.pkl'), 'rb') as f:\n",
+    "    videos = pickle.load(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "dfdda3e8-1a07-4a19-b3ee-db97e71a38a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<spatialyze.world.World at 0x285b4f7c0>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "world = World()\n",
+    "world.addGeogConstructs(RoadNetwork('Boston-Seaport', ROAD_DIR))\n",
+    "\n",
+    "for file in os.listdir(VIDEO_DIR):\n",
+    "    if not file.endswith('.camera.pkl'):\n",
+    "        continue\n",
+    "\n",
+    "    with open(os.path.join(VIDEO_DIR, file), 'rb') as f:\n",
+    "        camera = pickle.load(f)\n",
+    "    videofile = os.path.join(VIDEO_DIR, camera['filename'])\n",
+    "    camera = [camera_config(*c) for c in camera['frames']]\n",
+    "\n",
+    "    world.addVideo(GeospatialVideo(videofile, camera))\n",
+    "\n",
+    "car1 = world.object()\n",
+    "car2 = world.object()\n",
+    "car3 = world.object()\n",
+    "camera = world.camera()\n",
+    "lane = world.geogConstruct(type='lane')\n",
+    "\n",
+    "intersection = world.geogConstruct(type='intersection')\n",
+    "\n",
+    "world.filter(\n",
+    "    has_types(car1, 'car') & \n",
+    "    heading_diff(lane, car1, between=[-15, 15]) &\n",
+    "    (distance(camera, car1) <= 50) &\n",
+    "    (view_angle(camera, car1) <= 135) &\n",
+    "    has_types(car2, 'car') & \n",
+    "    contains(intersection, [camera, car2]) &\n",
+    "    heading_diff(car1, car2, between=[50, 135]) &\n",
+    "    has_types(car3, 'car') &\n",
+    "    heading_diff(car1, car3, between=[-135, -50]) &\n",
+    "    ~heading_diff(car1, car2, between=[-100, 100]) &\n",
+    "    (distance(car1, intersection) < 50)\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a5cc61d2-35db-4349-997c-9f64d06fad21",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "CallNode(_fn=(<function road_segment at 0x1374423b0>,), params=[LiteralNode(value='intersection', python=True)])",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[5], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mworld\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msaveVideos\u001b[49m\u001b[43m(\u001b[49m\u001b[43mos\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpath\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mjoin\u001b[49m\u001b[43m(\u001b[49m\u001b[43mOUTPUT_DIR\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mfigure13\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maddBoundingBoxes\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:108\u001b[0m, in \u001b[0;36mWorld.saveVideos\u001b[0;34m(self, outputDir, addBoundingBoxes)\u001b[0m\n\u001b[1;32m    106\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msaveVideos\u001b[39m(\u001b[38;5;28mself\u001b[39m, outputDir: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstr\u001b[39m\u001b[38;5;124m\"\u001b[39m, addBoundingBoxes: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbool\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m):\n\u001b[1;32m    107\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 108\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;241m=\u001b[39m \u001b[43m_execute\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m    109\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m save_video_util(\n\u001b[1;32m    110\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects,\n\u001b[1;32m    111\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings,\n\u001b[1;32m    112\u001b[0m         outputDir,\n\u001b[1;32m    113\u001b[0m         addBoundingBoxes,\n\u001b[1;32m    114\u001b[0m     )\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:161\u001b[0m, in \u001b[0;36m_execute\u001b[0;34m(world, optimization)\u001b[0m\n\u001b[1;32m    159\u001b[0m     decode \u001b[38;5;241m=\u001b[39m PruneFrames(prefilter, decode)\n\u001b[1;32m    160\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m optimization:\n\u001b[0;32m--> 161\u001b[0m     inview \u001b[38;5;241m=\u001b[39m \u001b[43mRoadVisibilityPruner\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdistance\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m50\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredicate\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mworld\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpredicates\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    162\u001b[0m     decode \u001b[38;5;241m=\u001b[39m PruneFrames(inview, decode)\n\u001b[1;32m    163\u001b[0m d2ds \u001b[38;5;241m=\u001b[39m detector(decode)\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stream/road_visibility_pruner.py:17\u001b[0m, in \u001b[0;36mRoadVisibilityPruner.__init__\u001b[0;34m(self, distance, roadtypes, predicate)\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\n\u001b[1;32m     12\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m     13\u001b[0m     distance: \u001b[38;5;28mfloat\u001b[39m,\n\u001b[1;32m     14\u001b[0m     roadtypes: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m|\u001b[39m \u001b[38;5;28mlist\u001b[39m[\u001b[38;5;28mstr\u001b[39m] \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     15\u001b[0m     predicate: PredicateNode \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     16\u001b[0m ):\n\u001b[0;32m---> 17\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39minview \u001b[38;5;241m=\u001b[39m \u001b[43mInView\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdistance\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mroadtypes\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredicate\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:61\u001b[0m, in \u001b[0;36mInView.__init__\u001b[0;34m(self, distance, roadtypes, predicate)\u001b[0m\n\u001b[1;32m     59\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m predicate \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m     60\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m roadtypes \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mCan only except either segment_type or predicate\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 61\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mroadtypes, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate_str \u001b[38;5;241m=\u001b[39m \u001b[43mcreate_inview_predicate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpredicate\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     62\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate \u001b[38;5;241m=\u001b[39m \u001b[38;5;28meval\u001b[39m(\u001b[38;5;28mstr\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate_str))\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:599\u001b[0m, in \u001b[0;36mcreate_inview_predicate\u001b[0;34m(node)\u001b[0m\n\u001b[1;32m    596\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mcreate_inview_predicate\u001b[39m(\n\u001b[1;32m    597\u001b[0m     node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mPredicateNode\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m    598\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtuple[list[str], str | bool]\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m--> 599\u001b[0m     node \u001b[38;5;241m=\u001b[39m \u001b[43mKeepOnlyRoadTypePredicates\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    600\u001b[0m     \u001b[38;5;66;03m# Note True/False will either disappear from all the predicates or propagate to the top\u001b[39;00m\n\u001b[1;32m    601\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node, LiteralNode):\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:245\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    244\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: BoolOpNode):\n\u001b[0;32m--> 245\u001b[0m     visited \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvisit_BoolOpNode\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    246\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(visited, BoolOpNode), visited\n\u001b[1;32m    247\u001b[0m     annihilator \u001b[38;5;241m=\u001b[39m ANNIHILATORS[node\u001b[38;5;241m.\u001b[39mop]\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36mBaseTransformer.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28mself\u001b[39m(e) \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43me\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:292\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_CallNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    289\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m node\u001b[38;5;241m.\u001b[39mfn \u001b[38;5;241m==\u001b[39m F\u001b[38;5;241m.\u001b[39mcontains()\u001b[38;5;241m.\u001b[39mfn:\n\u001b[1;32m    290\u001b[0m     \u001b[38;5;66;03m# print('contains')\u001b[39;00m\n\u001b[1;32m    291\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams) \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m2\u001b[39m\n\u001b[0;32m--> 292\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m], LiteralNode), node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    293\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\u001b[38;5;241m.\u001b[39mvalue, \u001b[38;5;28mstr\u001b[39m), node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    294\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m F\u001b[38;5;241m.\u001b[39mis_roadtype(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m])\n",
+      "\u001b[0;31mAssertionError\u001b[0m: CallNode(_fn=(<function road_segment at 0x1374423b0>,), params=[LiteralNode(value='intersection', python=True)])"
+     ]
+    }
+   ],
+   "source": [
+    "world.saveVideos(os.path.join(OUTPUT_DIR, 'figure13'), addBoundingBoxes=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/evaluation/examples/ianhdong/scenic-figure14.ipynb
+++ b/evaluation/examples/ianhdong/scenic-figure14.ipynb
@@ -1,0 +1,182 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b5324e5c-aabc-42d9-94cb-3dffae501e4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from os import environ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fbb7ced7-6d62-42ef-a839-8391c0c64e22",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'utils'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[3], line 13\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mvideo_processor\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcamera_config\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m camera_config\n\u001b[1;32m     12\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mutils\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mF\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m distance, contains, heading_diff, has_types, stopped, left_turn, view_angle\n\u001b[0;32m---> 13\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mutils\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m topdown_config, vv_config, resize\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'utils'"
+     ]
+    }
+   ],
+   "source": [
+    "import pickle\n",
+    "import os\n",
+    "import json\n",
+    "import random\n",
+    "\n",
+    "import cv2\n",
+    "\n",
+    "from spatialyze.geospatial_video import GeospatialVideo\n",
+    "from spatialyze.road_network import RoadNetwork\n",
+    "from spatialyze.world import World\n",
+    "from spatialyze.video_processor.camera_config import camera_config\n",
+    "from spatialyze.utils.F import distance, contains, heading_diff, has_types, stopped, left_turn, view_angle\n",
+    "from utils import topdown_config, vv_config, resize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "69551780-c87e-4c9c-9462-1906cc77bb33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_DIR = '../../../data'\n",
+    "OUTPUT_DIR = os.path.join(DATA_DIR, 'pipeline/outputs')\n",
+    "VIDEO_DIR = os.path.join(DATA_DIR, 'pipeline/videos')\n",
+    "ROAD_DIR = os.path.join(DATA_DIR, 'scenic/road-network/boston-seaport')\n",
+    "\n",
+    "files = os.listdir(VIDEO_DIR)\n",
+    "with open(os.path.join(VIDEO_DIR, 'frames.pkl'), 'rb') as f:\n",
+    "    videos = pickle.load(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "dfdda3e8-1a07-4a19-b3ee-db97e71a38a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<spatialyze.world.World at 0x17da5c400>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "world = World()\n",
+    "world.addGeogConstructs(RoadNetwork('Boston-Seaport', ROAD_DIR))\n",
+    "\n",
+    "for file in os.listdir(VIDEO_DIR):\n",
+    "    if not file.endswith('.camera.pkl'):\n",
+    "        continue\n",
+    "\n",
+    "    with open(os.path.join(VIDEO_DIR, file), 'rb') as f:\n",
+    "        camera = pickle.load(f)\n",
+    "    videofile = os.path.join(VIDEO_DIR, camera['filename'])\n",
+    "    camera = [camera_config(*c) for c in camera['frames']]\n",
+    "\n",
+    "    world.addVideo(GeospatialVideo(videofile, camera))\n",
+    "\n",
+    "random_float = random.uniform(-1, 1)\n",
+    "car = world.object()\n",
+    "car2 = world.object()\n",
+    "camera = world.camera()\n",
+    "lane = world.geogConstruct(type='lane')\n",
+    "\n",
+    "world.filter(\n",
+    "    has_types(car, 'car') &\n",
+    "    contains(lane, [camera, car]) & \n",
+    "    heading_diff(lane, car, between=[random_float * 90.0, random_float * 180.0]) & \n",
+    "    (distance(camera, car) < 50) & \n",
+    "    (view_angle(camera, car) < 135) &\n",
+    "    has_types(car2, 'car') &\n",
+    "    contains(lane, [camera, car2]) &\n",
+    "    heading_diff(lane, car2, between=[-15, 15]) &\n",
+    "    (distance(car, car2) < 10)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "a5cc61d2-35db-4349-997c-9f64d06fad21",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "CallNode(_fn=(<function road_segment at 0x107d01cf0>,), params=[LiteralNode(value='intersection', python=True)])",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[15], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mworld\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msaveVideos\u001b[49m\u001b[43m(\u001b[49m\u001b[43mos\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpath\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mjoin\u001b[49m\u001b[43m(\u001b[49m\u001b[43mOUTPUT_DIR\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mfigure12\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maddBoundingBoxes\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:108\u001b[0m, in \u001b[0;36mWorld.saveVideos\u001b[0;34m(self, outputDir, addBoundingBoxes)\u001b[0m\n\u001b[1;32m    106\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msaveVideos\u001b[39m(\u001b[38;5;28mself\u001b[39m, outputDir: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstr\u001b[39m\u001b[38;5;124m\"\u001b[39m, addBoundingBoxes: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbool\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m):\n\u001b[1;32m    107\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 108\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;241m=\u001b[39m \u001b[43m_execute\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m    109\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m save_video_util(\n\u001b[1;32m    110\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects,\n\u001b[1;32m    111\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings,\n\u001b[1;32m    112\u001b[0m         outputDir,\n\u001b[1;32m    113\u001b[0m         addBoundingBoxes,\n\u001b[1;32m    114\u001b[0m     )\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:161\u001b[0m, in \u001b[0;36m_execute\u001b[0;34m(world, optimization)\u001b[0m\n\u001b[1;32m    159\u001b[0m     decode \u001b[38;5;241m=\u001b[39m PruneFrames(prefilter, decode)\n\u001b[1;32m    160\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m optimization:\n\u001b[0;32m--> 161\u001b[0m     inview \u001b[38;5;241m=\u001b[39m \u001b[43mRoadVisibilityPruner\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdistance\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m50\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredicate\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mworld\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpredicates\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    162\u001b[0m     decode \u001b[38;5;241m=\u001b[39m PruneFrames(inview, decode)\n\u001b[1;32m    163\u001b[0m d2ds \u001b[38;5;241m=\u001b[39m detector(decode)\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stream/road_visibility_pruner.py:17\u001b[0m, in \u001b[0;36mRoadVisibilityPruner.__init__\u001b[0;34m(self, distance, roadtypes, predicate)\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\n\u001b[1;32m     12\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m     13\u001b[0m     distance: \u001b[38;5;28mfloat\u001b[39m,\n\u001b[1;32m     14\u001b[0m     roadtypes: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m|\u001b[39m \u001b[38;5;28mlist\u001b[39m[\u001b[38;5;28mstr\u001b[39m] \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     15\u001b[0m     predicate: PredicateNode \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     16\u001b[0m ):\n\u001b[0;32m---> 17\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39minview \u001b[38;5;241m=\u001b[39m \u001b[43mInView\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdistance\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mroadtypes\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredicate\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:61\u001b[0m, in \u001b[0;36mInView.__init__\u001b[0;34m(self, distance, roadtypes, predicate)\u001b[0m\n\u001b[1;32m     59\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m predicate \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m     60\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m roadtypes \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mCan only except either segment_type or predicate\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 61\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mroadtypes, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate_str \u001b[38;5;241m=\u001b[39m \u001b[43mcreate_inview_predicate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpredicate\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     62\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate \u001b[38;5;241m=\u001b[39m \u001b[38;5;28meval\u001b[39m(\u001b[38;5;28mstr\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate_str))\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:599\u001b[0m, in \u001b[0;36mcreate_inview_predicate\u001b[0;34m(node)\u001b[0m\n\u001b[1;32m    596\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mcreate_inview_predicate\u001b[39m(\n\u001b[1;32m    597\u001b[0m     node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mPredicateNode\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m    598\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtuple[list[str], str | bool]\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m--> 599\u001b[0m     node \u001b[38;5;241m=\u001b[39m \u001b[43mKeepOnlyRoadTypePredicates\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    600\u001b[0m     \u001b[38;5;66;03m# Note True/False will either disappear from all the predicates or propagate to the top\u001b[39;00m\n\u001b[1;32m    601\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node, LiteralNode):\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:245\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    244\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: BoolOpNode):\n\u001b[0;32m--> 245\u001b[0m     visited \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvisit_BoolOpNode\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    246\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(visited, BoolOpNode), visited\n\u001b[1;32m    247\u001b[0m     annihilator \u001b[38;5;241m=\u001b[39m ANNIHILATORS[node\u001b[38;5;241m.\u001b[39mop]\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36mBaseTransformer.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28mself\u001b[39m(e) \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43me\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:245\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    244\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: BoolOpNode):\n\u001b[0;32m--> 245\u001b[0m     visited \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvisit_BoolOpNode\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    246\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(visited, BoolOpNode), visited\n\u001b[1;32m    247\u001b[0m     annihilator \u001b[38;5;241m=\u001b[39m ANNIHILATORS[node\u001b[38;5;241m.\u001b[39mop]\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36mBaseTransformer.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28mself\u001b[39m(e) \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43me\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:292\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_CallNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    289\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m node\u001b[38;5;241m.\u001b[39mfn \u001b[38;5;241m==\u001b[39m F\u001b[38;5;241m.\u001b[39mcontains()\u001b[38;5;241m.\u001b[39mfn:\n\u001b[1;32m    290\u001b[0m     \u001b[38;5;66;03m# print('contains')\u001b[39;00m\n\u001b[1;32m    291\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams) \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m2\u001b[39m\n\u001b[0;32m--> 292\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m], LiteralNode), node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    293\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\u001b[38;5;241m.\u001b[39mvalue, \u001b[38;5;28mstr\u001b[39m), node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    294\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m F\u001b[38;5;241m.\u001b[39mis_roadtype(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m])\n",
+      "\u001b[0;31mAssertionError\u001b[0m: CallNode(_fn=(<function road_segment at 0x107d01cf0>,), params=[LiteralNode(value='intersection', python=True)])"
+     ]
+    }
+   ],
+   "source": [
+    "world.saveVideos(os.path.join(OUTPUT_DIR, 'figure12'), addBoundingBoxes=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "affbc518-8948-469a-9e40-08fce69e4161",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/evaluation/examples/ianhdong/scenic-figure15.ipynb
+++ b/evaluation/examples/ianhdong/scenic-figure15.ipynb
@@ -1,0 +1,199 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b5324e5c-aabc-42d9-94cb-3dffae501e4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from os import environ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "fbb7ced7-6d62-42ef-a839-8391c0c64e22",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'utils'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[5], line 13\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mvideo_processor\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcamera_config\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m camera_config\n\u001b[1;32m     12\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mutils\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mF\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m distance, custom_fn, contains, has_types, heading_diff, stopped, left_turn, view_angle\n\u001b[0;32m---> 13\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mutils\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m topdown_config, vv_config, resize\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'utils'"
+     ]
+    }
+   ],
+   "source": [
+    "import pickle\n",
+    "import os\n",
+    "import json\n",
+    "import random\n",
+    "\n",
+    "import cv2\n",
+    "\n",
+    "from spatialyze.geospatial_video import GeospatialVideo\n",
+    "from spatialyze.road_network import RoadNetwork\n",
+    "from spatialyze.world import World\n",
+    "from spatialyze.video_processor.camera_config import camera_config\n",
+    "from spatialyze.utils.F import distance, custom_fn, contains, has_types, heading_diff, stopped, left_turn, view_angle\n",
+    "from utils import topdown_config, vv_config, resize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "69551780-c87e-4c9c-9462-1906cc77bb33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_DIR = '../../../data'\n",
+    "OUTPUT_DIR = os.path.join(DATA_DIR, 'pipeline/outputs')\n",
+    "VIDEO_DIR = os.path.join(DATA_DIR, 'pipeline/videos')\n",
+    "ROAD_DIR = os.path.join(DATA_DIR, 'scenic/road-network/boston-seaport')\n",
+    "\n",
+    "files = os.listdir(VIDEO_DIR)\n",
+    "with open(os.path.join(VIDEO_DIR, 'frames.pkl'), 'rb') as f:\n",
+    "    videos = pickle.load(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "dfdda3e8-1a07-4a19-b3ee-db97e71a38a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<spatialyze.world.World at 0x2917a2380>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "world = World()\n",
+    "world.addGeogConstructs(RoadNetwork('Boston-Seaport', ROAD_DIR))\n",
+    "\n",
+    "for file in os.listdir(VIDEO_DIR):\n",
+    "    if not file.endswith('.camera.pkl'):\n",
+    "        continue\n",
+    "\n",
+    "    with open(os.path.join(VIDEO_DIR, file), 'rb') as f:\n",
+    "        camera = pickle.load(f)\n",
+    "    videofile = os.path.join(VIDEO_DIR, camera['filename'])\n",
+    "    camera = [camera_config(*c) for c in camera['frames']]\n",
+    "\n",
+    "    world.addVideo(GeospatialVideo(videofile, camera))\n",
+    "\n",
+    "car1 = world.object()\n",
+    "car2 = world.object()\n",
+    "car3 = world.object()\n",
+    "point1 = world.object()\n",
+    "point2 = world.object()\n",
+    "camera = world.camera()\n",
+    "lane = world.geogConstruct(type='lane')\n",
+    "\n",
+    "intersection = world.geogConstruct(type='intersection')\n",
+    "\n",
+    "ahead_func = custom_fn.custom_fn(\"ahead\", 3)\n",
+    "\n",
+    "world.filter(\n",
+    "    has_types(car1, 'car') & \n",
+    "    heading_diff(lane, car1, between=[-15, 15]) &\n",
+    "    (distance(camera, car1) <= 50) &\n",
+    "    (view_angle(camera, car1) <= 135) &\n",
+    "    ahead_func(car1, point1, between=[0, 40]) &\n",
+    "    has_types(car2, 'car') &\n",
+    "    heading_diff(car1, car2, between=[140, 180]) &\n",
+    "    heading_diff(point1, lane, between=[-15, 15]) &\n",
+    "    heading_diff(point2, lane, between=[-15,15])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af37fa7b-e206-428d-88a1-a301d40069c0",
+   "metadata": {},
+   "source": [
+    "# Offset points\n",
+    "Can create bounding box to fix offset from single moveable object to another moveable object\n",
+    "\n",
+    "Use this as an additional filter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "a5cc61d2-35db-4349-997c-9f64d06fad21",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "CallNode(_fn=(<function road_segment at 0x107d01cf0>,), params=[LiteralNode(value='intersection', python=True)])",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[15], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mworld\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msaveVideos\u001b[49m\u001b[43m(\u001b[49m\u001b[43mos\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpath\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mjoin\u001b[49m\u001b[43m(\u001b[49m\u001b[43mOUTPUT_DIR\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mfigure12\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maddBoundingBoxes\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:108\u001b[0m, in \u001b[0;36mWorld.saveVideos\u001b[0;34m(self, outputDir, addBoundingBoxes)\u001b[0m\n\u001b[1;32m    106\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msaveVideos\u001b[39m(\u001b[38;5;28mself\u001b[39m, outputDir: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstr\u001b[39m\u001b[38;5;124m\"\u001b[39m, addBoundingBoxes: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbool\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m):\n\u001b[1;32m    107\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 108\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;241m=\u001b[39m \u001b[43m_execute\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m    109\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m save_video_util(\n\u001b[1;32m    110\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects,\n\u001b[1;32m    111\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings,\n\u001b[1;32m    112\u001b[0m         outputDir,\n\u001b[1;32m    113\u001b[0m         addBoundingBoxes,\n\u001b[1;32m    114\u001b[0m     )\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:161\u001b[0m, in \u001b[0;36m_execute\u001b[0;34m(world, optimization)\u001b[0m\n\u001b[1;32m    159\u001b[0m     decode \u001b[38;5;241m=\u001b[39m PruneFrames(prefilter, decode)\n\u001b[1;32m    160\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m optimization:\n\u001b[0;32m--> 161\u001b[0m     inview \u001b[38;5;241m=\u001b[39m \u001b[43mRoadVisibilityPruner\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdistance\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m50\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredicate\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mworld\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpredicates\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    162\u001b[0m     decode \u001b[38;5;241m=\u001b[39m PruneFrames(inview, decode)\n\u001b[1;32m    163\u001b[0m d2ds \u001b[38;5;241m=\u001b[39m detector(decode)\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stream/road_visibility_pruner.py:17\u001b[0m, in \u001b[0;36mRoadVisibilityPruner.__init__\u001b[0;34m(self, distance, roadtypes, predicate)\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\n\u001b[1;32m     12\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m     13\u001b[0m     distance: \u001b[38;5;28mfloat\u001b[39m,\n\u001b[1;32m     14\u001b[0m     roadtypes: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m|\u001b[39m \u001b[38;5;28mlist\u001b[39m[\u001b[38;5;28mstr\u001b[39m] \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     15\u001b[0m     predicate: PredicateNode \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     16\u001b[0m ):\n\u001b[0;32m---> 17\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39minview \u001b[38;5;241m=\u001b[39m \u001b[43mInView\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdistance\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mroadtypes\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredicate\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:61\u001b[0m, in \u001b[0;36mInView.__init__\u001b[0;34m(self, distance, roadtypes, predicate)\u001b[0m\n\u001b[1;32m     59\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m predicate \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m     60\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m roadtypes \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mCan only except either segment_type or predicate\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 61\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mroadtypes, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate_str \u001b[38;5;241m=\u001b[39m \u001b[43mcreate_inview_predicate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpredicate\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     62\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate \u001b[38;5;241m=\u001b[39m \u001b[38;5;28meval\u001b[39m(\u001b[38;5;28mstr\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate_str))\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:599\u001b[0m, in \u001b[0;36mcreate_inview_predicate\u001b[0;34m(node)\u001b[0m\n\u001b[1;32m    596\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mcreate_inview_predicate\u001b[39m(\n\u001b[1;32m    597\u001b[0m     node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mPredicateNode\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m    598\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtuple[list[str], str | bool]\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m--> 599\u001b[0m     node \u001b[38;5;241m=\u001b[39m \u001b[43mKeepOnlyRoadTypePredicates\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    600\u001b[0m     \u001b[38;5;66;03m# Note True/False will either disappear from all the predicates or propagate to the top\u001b[39;00m\n\u001b[1;32m    601\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node, LiteralNode):\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:245\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    244\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: BoolOpNode):\n\u001b[0;32m--> 245\u001b[0m     visited \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvisit_BoolOpNode\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    246\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(visited, BoolOpNode), visited\n\u001b[1;32m    247\u001b[0m     annihilator \u001b[38;5;241m=\u001b[39m ANNIHILATORS[node\u001b[38;5;241m.\u001b[39mop]\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36mBaseTransformer.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28mself\u001b[39m(e) \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43me\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:245\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    244\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: BoolOpNode):\n\u001b[0;32m--> 245\u001b[0m     visited \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvisit_BoolOpNode\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    246\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(visited, BoolOpNode), visited\n\u001b[1;32m    247\u001b[0m     annihilator \u001b[38;5;241m=\u001b[39m ANNIHILATORS[node\u001b[38;5;241m.\u001b[39mop]\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36mBaseTransformer.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28mself\u001b[39m(e) \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43me\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:292\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_CallNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    289\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m node\u001b[38;5;241m.\u001b[39mfn \u001b[38;5;241m==\u001b[39m F\u001b[38;5;241m.\u001b[39mcontains()\u001b[38;5;241m.\u001b[39mfn:\n\u001b[1;32m    290\u001b[0m     \u001b[38;5;66;03m# print('contains')\u001b[39;00m\n\u001b[1;32m    291\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams) \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m2\u001b[39m\n\u001b[0;32m--> 292\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m], LiteralNode), node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    293\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\u001b[38;5;241m.\u001b[39mvalue, \u001b[38;5;28mstr\u001b[39m), node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    294\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m F\u001b[38;5;241m.\u001b[39mis_roadtype(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m])\n",
+      "\u001b[0;31mAssertionError\u001b[0m: CallNode(_fn=(<function road_segment at 0x107d01cf0>,), params=[LiteralNode(value='intersection', python=True)])"
+     ]
+    }
+   ],
+   "source": [
+    "world.saveVideos(os.path.join(OUTPUT_DIR, 'figure12'), addBoundingBoxes=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "affbc518-8948-469a-9e40-08fce69e4161",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/evaluation/examples/ianhdong/scenic-figure16.ipynb
+++ b/evaluation/examples/ianhdong/scenic-figure16.ipynb
@@ -1,0 +1,185 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b5324e5c-aabc-42d9-94cb-3dffae501e4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from os import environ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fbb7ced7-6d62-42ef-a839-8391c0c64e22",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'utils'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[4], line 13\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mvideo_processor\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcamera_config\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m camera_config\n\u001b[1;32m     12\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mutils\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mF\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m distance, custom_fn, contains, has_types, heading_diff, road_direction, stopped, left_turn, view_angle\n\u001b[0;32m---> 13\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mutils\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m topdown_config, vv_config, resize\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'utils'"
+     ]
+    }
+   ],
+   "source": [
+    "import pickle\n",
+    "import os\n",
+    "import json\n",
+    "import random\n",
+    "\n",
+    "import cv2\n",
+    "\n",
+    "from spatialyze.geospatial_video import GeospatialVideo\n",
+    "from spatialyze.road_network import RoadNetwork\n",
+    "from spatialyze.world import World\n",
+    "from spatialyze.video_processor.camera_config import camera_config\n",
+    "from spatialyze.utils.F import distance, custom_fn, contains, has_types, heading_diff, road_direction, stopped, left_turn, view_angle\n",
+    "from utils import topdown_config, vv_config, resize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "69551780-c87e-4c9c-9462-1906cc77bb33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_DIR = '../../../data'\n",
+    "OUTPUT_DIR = os.path.join(DATA_DIR, 'pipeline/outputs')\n",
+    "VIDEO_DIR = os.path.join(DATA_DIR, 'pipeline/videos')\n",
+    "ROAD_DIR = os.path.join(DATA_DIR, 'scenic/road-network/boston-seaport')\n",
+    "\n",
+    "files = os.listdir(VIDEO_DIR)\n",
+    "with open(os.path.join(VIDEO_DIR, 'frames.pkl'), 'rb') as f:\n",
+    "    videos = pickle.load(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "dfdda3e8-1a07-4a19-b3ee-db97e71a38a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<spatialyze.world.World at 0x289ae1f60>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "world = World()\n",
+    "world.addGeogConstructs(RoadNetwork('Boston-Seaport', ROAD_DIR))\n",
+    "\n",
+    "for file in os.listdir(VIDEO_DIR):\n",
+    "    if not file.endswith('.camera.pkl'):\n",
+    "        continue\n",
+    "\n",
+    "    with open(os.path.join(VIDEO_DIR, file), 'rb') as f:\n",
+    "        camera = pickle.load(f)\n",
+    "    videofile = os.path.join(VIDEO_DIR, camera['filename'])\n",
+    "    camera = [camera_config(*c) for c in camera['frames']]\n",
+    "\n",
+    "    world.addVideo(GeospatialVideo(videofile, camera))\n",
+    "\n",
+    "car = world.object()\n",
+    "lane = world.geogConstruct(type='lane')\n",
+    "cutInCar = world.object()\n",
+    "world.filter(\n",
+    "    has_types(car, 'car') & \n",
+    "    heading_diff(lane, car, between=[-15, 15]) &\n",
+    "    heading_diff(lane, car, between=[-30, -15]) &\n",
+    "    road_direction(lane, right=True)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af37fa7b-e206-428d-88a1-a301d40069c0",
+   "metadata": {},
+   "source": [
+    "# Filters out Multiple Lanes\n",
+    "Can possibly create a data structure to maintina all of the matches corresponding to filter\n",
+    "\n",
+    "Will be used for future filters based on moveable object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "a5cc61d2-35db-4349-997c-9f64d06fad21",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AssertionError",
+     "evalue": "CallNode(_fn=(<function road_segment at 0x107d01cf0>,), params=[LiteralNode(value='intersection', python=True)])",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[15], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mworld\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msaveVideos\u001b[49m\u001b[43m(\u001b[49m\u001b[43mos\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpath\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mjoin\u001b[49m\u001b[43m(\u001b[49m\u001b[43mOUTPUT_DIR\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mfigure12\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maddBoundingBoxes\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:108\u001b[0m, in \u001b[0;36mWorld.saveVideos\u001b[0;34m(self, outputDir, addBoundingBoxes)\u001b[0m\n\u001b[1;32m    106\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msaveVideos\u001b[39m(\u001b[38;5;28mself\u001b[39m, outputDir: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstr\u001b[39m\u001b[38;5;124m\"\u001b[39m, addBoundingBoxes: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbool\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m):\n\u001b[1;32m    107\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 108\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;241m=\u001b[39m \u001b[43m_execute\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m    109\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m save_video_util(\n\u001b[1;32m    110\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects,\n\u001b[1;32m    111\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings,\n\u001b[1;32m    112\u001b[0m         outputDir,\n\u001b[1;32m    113\u001b[0m         addBoundingBoxes,\n\u001b[1;32m    114\u001b[0m     )\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:161\u001b[0m, in \u001b[0;36m_execute\u001b[0;34m(world, optimization)\u001b[0m\n\u001b[1;32m    159\u001b[0m     decode \u001b[38;5;241m=\u001b[39m PruneFrames(prefilter, decode)\n\u001b[1;32m    160\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m optimization:\n\u001b[0;32m--> 161\u001b[0m     inview \u001b[38;5;241m=\u001b[39m \u001b[43mRoadVisibilityPruner\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdistance\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m50\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredicate\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mworld\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpredicates\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    162\u001b[0m     decode \u001b[38;5;241m=\u001b[39m PruneFrames(inview, decode)\n\u001b[1;32m    163\u001b[0m d2ds \u001b[38;5;241m=\u001b[39m detector(decode)\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stream/road_visibility_pruner.py:17\u001b[0m, in \u001b[0;36mRoadVisibilityPruner.__init__\u001b[0;34m(self, distance, roadtypes, predicate)\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\n\u001b[1;32m     12\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m     13\u001b[0m     distance: \u001b[38;5;28mfloat\u001b[39m,\n\u001b[1;32m     14\u001b[0m     roadtypes: \u001b[38;5;28mstr\u001b[39m \u001b[38;5;241m|\u001b[39m \u001b[38;5;28mlist\u001b[39m[\u001b[38;5;28mstr\u001b[39m] \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     15\u001b[0m     predicate: PredicateNode \u001b[38;5;241m|\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m     16\u001b[0m ):\n\u001b[0;32m---> 17\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39minview \u001b[38;5;241m=\u001b[39m \u001b[43mInView\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdistance\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mroadtypes\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpredicate\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:61\u001b[0m, in \u001b[0;36mInView.__init__\u001b[0;34m(self, distance, roadtypes, predicate)\u001b[0m\n\u001b[1;32m     59\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m predicate \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m     60\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m roadtypes \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mCan only except either segment_type or predicate\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[0;32m---> 61\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mroadtypes, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate_str \u001b[38;5;241m=\u001b[39m \u001b[43mcreate_inview_predicate\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpredicate\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     62\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate \u001b[38;5;241m=\u001b[39m \u001b[38;5;28meval\u001b[39m(\u001b[38;5;28mstr\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mpredicate_str))\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:599\u001b[0m, in \u001b[0;36mcreate_inview_predicate\u001b[0;34m(node)\u001b[0m\n\u001b[1;32m    596\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mcreate_inview_predicate\u001b[39m(\n\u001b[1;32m    597\u001b[0m     node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mPredicateNode\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m    598\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtuple[list[str], str | bool]\u001b[39m\u001b[38;5;124m\"\u001b[39m:\n\u001b[0;32m--> 599\u001b[0m     node \u001b[38;5;241m=\u001b[39m \u001b[43mKeepOnlyRoadTypePredicates\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    600\u001b[0m     \u001b[38;5;66;03m# Note True/False will either disappear from all the predicates or propagate to the top\u001b[39;00m\n\u001b[1;32m    601\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node, LiteralNode):\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:245\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    244\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: BoolOpNode):\n\u001b[0;32m--> 245\u001b[0m     visited \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvisit_BoolOpNode\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    246\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(visited, BoolOpNode), visited\n\u001b[1;32m    247\u001b[0m     annihilator \u001b[38;5;241m=\u001b[39m ANNIHILATORS[node\u001b[38;5;241m.\u001b[39mop]\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36mBaseTransformer.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28mself\u001b[39m(e) \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43me\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:245\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    244\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: BoolOpNode):\n\u001b[0;32m--> 245\u001b[0m     visited \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvisit_BoolOpNode\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    246\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(visited, BoolOpNode), visited\n\u001b[1;32m    247\u001b[0m     annihilator \u001b[38;5;241m=\u001b[39m ANNIHILATORS[node\u001b[38;5;241m.\u001b[39mop]\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36mBaseTransformer.visit_BoolOpNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28mself\u001b[39m(e) \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:353\u001b[0m, in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m    352\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mvisit_BoolOpNode\u001b[39m(\u001b[38;5;28mself\u001b[39m, node: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mBoolOpNode\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m PredicateNode:\n\u001b[0;32m--> 353\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m BoolOpNode(node\u001b[38;5;241m.\u001b[39mop, [\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43me\u001b[49m\u001b[43m)\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m e \u001b[38;5;129;01min\u001b[39;00m node\u001b[38;5;241m.\u001b[39mexprs])\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/predicate.py:295\u001b[0m, in \u001b[0;36mVisitor.__call__\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    293\u001b[0m attr \u001b[38;5;241m=\u001b[39m \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mvisit_\u001b[39m\u001b[38;5;132;01m{\u001b[39;00mnode\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    294\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(\u001b[38;5;28mself\u001b[39m, attr), \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mUnknown node type: \u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m+\u001b[39m node\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m\n\u001b[0;32m--> 295\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mgetattr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mattr\u001b[49m\u001b[43m)\u001b[49m\u001b[43m(\u001b[49m\u001b[43mnode\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stages/in_view/in_view.py:292\u001b[0m, in \u001b[0;36mKeepOnlyRoadTypePredicates.visit_CallNode\u001b[0;34m(self, node)\u001b[0m\n\u001b[1;32m    289\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m node\u001b[38;5;241m.\u001b[39mfn \u001b[38;5;241m==\u001b[39m F\u001b[38;5;241m.\u001b[39mcontains()\u001b[38;5;241m.\u001b[39mfn:\n\u001b[1;32m    290\u001b[0m     \u001b[38;5;66;03m# print('contains')\u001b[39;00m\n\u001b[1;32m    291\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams) \u001b[38;5;241m==\u001b[39m \u001b[38;5;241m2\u001b[39m\n\u001b[0;32m--> 292\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m], LiteralNode), node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    293\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\u001b[38;5;241m.\u001b[39mvalue, \u001b[38;5;28mstr\u001b[39m), node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    294\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m F\u001b[38;5;241m.\u001b[39mis_roadtype(node\u001b[38;5;241m.\u001b[39mparams[\u001b[38;5;241m0\u001b[39m])\n",
+      "\u001b[0;31mAssertionError\u001b[0m: CallNode(_fn=(<function road_segment at 0x107d01cf0>,), params=[LiteralNode(value='intersection', python=True)])"
+     ]
+    }
+   ],
+   "source": [
+    "world.saveVideos(os.path.join(OUTPUT_DIR, 'figure12'), addBoundingBoxes=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "affbc518-8948-469a-9e40-08fce69e4161",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/evaluation/examples/ianhdong/skyquery-figure5a.ipynb
+++ b/evaluation/examples/ianhdong/skyquery-figure5a.ipynb
@@ -1,0 +1,187 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b5324e5c-aabc-42d9-94cb-3dffae501e4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from os import environ"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fbb7ced7-6d62-42ef-a839-8391c0c64e22",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CUDA is not available.\n"
+     ]
+    },
+    {
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'utils'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[3], line 13\u001b[0m\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mvideo_processor\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mcamera_config\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m camera_config\n\u001b[1;32m     12\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mspatialyze\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mutils\u001b[39;00m\u001b[38;5;21;01m.\u001b[39;00m\u001b[38;5;21;01mF\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m distance, custom_fn, contains, has_types, heading_diff, road_direction, stopped, left_turn, view_angle\n\u001b[0;32m---> 13\u001b[0m \u001b[38;5;28;01mfrom\u001b[39;00m \u001b[38;5;21;01mutils\u001b[39;00m \u001b[38;5;28;01mimport\u001b[39;00m topdown_config, vv_config, resize\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'utils'"
+     ]
+    }
+   ],
+   "source": [
+    "import pickle\n",
+    "import os\n",
+    "import json\n",
+    "import random\n",
+    "\n",
+    "import cv2\n",
+    "\n",
+    "from spatialyze.geospatial_video import GeospatialVideo\n",
+    "from spatialyze.road_network import RoadNetwork\n",
+    "from spatialyze.world import World\n",
+    "from spatialyze.video_processor.camera_config import camera_config\n",
+    "from spatialyze.utils.F import distance, custom_fn, contains, has_types, heading_diff, road_direction, stopped, left_turn, view_angle\n",
+    "from utils import topdown_config, vv_config, resize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "69551780-c87e-4c9c-9462-1906cc77bb33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DATA_DIR = '../../../data'\n",
+    "OUTPUT_DIR = os.path.join(DATA_DIR, 'pipeline/outputs')\n",
+    "VIDEO_DIR = os.path.join(DATA_DIR, 'pipeline/videos')\n",
+    "ROAD_DIR = os.path.join(DATA_DIR, 'scenic/road-network/boston-seaport')\n",
+    "\n",
+    "files = os.listdir(VIDEO_DIR)\n",
+    "with open(os.path.join(VIDEO_DIR, 'frames.pkl'), 'rb') as f:\n",
+    "    videos = pickle.load(f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "dfdda3e8-1a07-4a19-b3ee-db97e71a38a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<spatialyze.world.World at 0x289654370>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "world = World()\n",
+    "world.addGeogConstructs(RoadNetwork('Boston-Seaport', ROAD_DIR))\n",
+    "\n",
+    "for file in os.listdir(VIDEO_DIR):\n",
+    "    if not file.endswith('.camera.pkl'):\n",
+    "        continue\n",
+    "\n",
+    "    with open(os.path.join(VIDEO_DIR, file), 'rb') as f:\n",
+    "        camera = pickle.load(f)\n",
+    "    videofile = os.path.join(VIDEO_DIR, camera['filename'])\n",
+    "    camera = [camera_config(*c) for c in camera['frames']]\n",
+    "\n",
+    "    world.addVideo(GeospatialVideo(videofile, camera))\n",
+    "\n",
+    "car = world.object()\n",
+    "camera = world.camera()\n",
+    "lane = world.geogConstruct(type='lane')\n",
+    "world.filter(\n",
+    "    has_types(car, 'car') & \n",
+    "    stopped(car) &\n",
+    "    (distance(camera, car) < 3)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af37fa7b-e206-428d-88a1-a301d40069c0",
+   "metadata": {},
+   "source": [
+    "# Produce Matrix\n",
+    "This operator transforms a sequence dataframe into a matrix. Each matrix divides the region into\n",
+    "a grid of cells under a user-configurable cell size before aggregating each cell.\n",
+    "\n",
+    "Should splice after all conditionals have been added to filter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a5cc61d2-35db-4349-997c-9f64d06fad21",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/iandong/anaconda3/envs/spatialyze/lib/python3.10/site-packages/torch/hub.py:267: UserWarning: You are about to download and run code from an untrusted repository. In a future release, this won't be allowed. To add the repository to your trusted list, change the command to {calling_fn}(..., trust_repo=False) and a command prompt will appear asking for an explicit confirmation of trust, or load(..., trust_repo=True), which will assume that the prompt is to be answered with 'yes'. You can also use load(..., trust_repo='check') which will only prompt for confirmation if the repo is not already trusted. This will eventually be the default behaviour\n",
+      "  warnings.warn(\n",
+      "Downloading: \"https://github.com/ultralytics/yolov5/zipball/v7.0\" to /Users/iandong/weights/v7.0.zip\n"
+     ]
+    },
+    {
+     "ename": "AttributeError",
+     "evalue": "'NoneType' object has no attribute 'groups'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[7], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[43mworld\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43msaveVideos\u001b[49m\u001b[43m(\u001b[49m\u001b[43mos\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mpath\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mjoin\u001b[49m\u001b[43m(\u001b[49m\u001b[43mOUTPUT_DIR\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mfigure12\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maddBoundingBoxes\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:108\u001b[0m, in \u001b[0;36mWorld.saveVideos\u001b[0;34m(self, outputDir, addBoundingBoxes)\u001b[0m\n\u001b[1;32m    106\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21msaveVideos\u001b[39m(\u001b[38;5;28mself\u001b[39m, outputDir: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mstr\u001b[39m\u001b[38;5;124m\"\u001b[39m, addBoundingBoxes: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbool\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m):\n\u001b[1;32m    107\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 108\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings \u001b[38;5;241m=\u001b[39m \u001b[43m_execute\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m    109\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m save_video_util(\n\u001b[1;32m    110\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_objects,\n\u001b[1;32m    111\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_trackings,\n\u001b[1;32m    112\u001b[0m         outputDir,\n\u001b[1;32m    113\u001b[0m         addBoundingBoxes,\n\u001b[1;32m    114\u001b[0m     )\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:179\u001b[0m, in \u001b[0;36m_execute\u001b[0;34m(world, optimization)\u001b[0m\n\u001b[1;32m    177\u001b[0m video \u001b[38;5;241m=\u001b[39m Video(v\u001b[38;5;241m.\u001b[39mvideo, v\u001b[38;5;241m.\u001b[39mcamera)\n\u001b[1;32m    178\u001b[0m process \u001b[38;5;241m=\u001b[39m _track(t3ds) \u001b[38;5;28;01mif\u001b[39;00m temporal \u001b[38;5;28;01melse\u001b[39;00m _detect(d3ds)\n\u001b[0;32m--> 179\u001b[0m vresults[v\u001b[38;5;241m.\u001b[39mvideo] \u001b[38;5;241m=\u001b[39m \u001b[43mprocess\u001b[49m\u001b[43m(\u001b[49m\u001b[43mvideo\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdatabase\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    181\u001b[0m \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mall\u001b[39m(idx \u001b[38;5;241m==\u001b[39m cc\u001b[38;5;241m.\u001b[39mframe_num \u001b[38;5;28;01mfor\u001b[39;00m idx, cc \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28menumerate\u001b[39m(v\u001b[38;5;241m.\u001b[39mcamera)), [\n\u001b[1;32m    182\u001b[0m     cc\u001b[38;5;241m.\u001b[39mframe_num \u001b[38;5;28;01mfor\u001b[39;00m cc \u001b[38;5;129;01min\u001b[39;00m v\u001b[38;5;241m.\u001b[39mcamera\n\u001b[1;32m    183\u001b[0m ]\n\u001b[1;32m    184\u001b[0m qresults[v\u001b[38;5;241m.\u001b[39mvideo] \u001b[38;5;241m=\u001b[39m database\u001b[38;5;241m.\u001b[39mpredicate(world\u001b[38;5;241m.\u001b[39mpredicates, temporal)\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/world.py:191\u001b[0m, in \u001b[0;36m_track.<locals>._\u001b[0;34m(video, database)\u001b[0m\n\u001b[1;32m    189\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_\u001b[39m(video: Video, database: Database):\n\u001b[1;32m    190\u001b[0m     vresults: \u001b[38;5;28mlist\u001b[39m[TrackingResults] \u001b[38;5;241m=\u001b[39m []\n\u001b[0;32m--> 191\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m track \u001b[38;5;129;01min\u001b[39;00m processor\u001b[38;5;241m.\u001b[39miterate(video):\n\u001b[1;32m    192\u001b[0m         \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(track, Skip)\n\u001b[1;32m    193\u001b[0m         vresults\u001b[38;5;241m.\u001b[39mappend(track)\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stream/stream.py:52\u001b[0m, in \u001b[0;36mStream.stream\u001b[0;34m(self, video)\u001b[0m\n\u001b[1;32m     50\u001b[0m \u001b[38;5;28;01mwhile\u001b[39;00m \u001b[38;5;28;01mTrue\u001b[39;00m:\n\u001b[1;32m     51\u001b[0m     \u001b[38;5;28;01mwhile\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_results) \u001b[38;5;241m<\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_stream_progress[idx]:\n\u001b[0;32m---> 52\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_results\u001b[38;5;241m.\u001b[39mappend(\u001b[38;5;28;43mnext\u001b[39;49m\u001b[43m(\u001b[49m\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_iter_stream\u001b[49m\u001b[43m)\u001b[49m)\n\u001b[1;32m     54\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_results[\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_stream_progress[idx]]\n\u001b[1;32m     55\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m result \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/stream/strongsort.py:48\u001b[0m, in \u001b[0;36mStrongSORT._stream\u001b[0;34m(self, video)\u001b[0m\n\u001b[1;32m     46\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_stream\u001b[39m(\u001b[38;5;28mself\u001b[39m, video: Video):\n\u001b[1;32m     47\u001b[0m     device \u001b[38;5;241m=\u001b[39m select_device()\n\u001b[0;32m---> 48\u001b[0m     strongsort \u001b[38;5;241m=\u001b[39m \u001b[43mcreate_tracker\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mstrongsort\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mREID_WEIGHTS\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m)\u001b[49m\n\u001b[1;32m     49\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28misinstance\u001b[39m(strongsort, _StrongSORT)\n\u001b[1;32m     50\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(strongsort, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mtracker\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/modules/yolo_tracker/trackers/multi_tracker_zoo.py:15\u001b[0m, in \u001b[0;36mcreate_tracker\u001b[0;34m(tracker_type, appearance_descriptor_weights, device, half)\u001b[0m\n\u001b[1;32m     12\u001b[0m     \u001b[38;5;28;01mwith\u001b[39;00m \u001b[38;5;28mopen\u001b[39m(FILE\u001b[38;5;241m.\u001b[39mparent \u001b[38;5;241m/\u001b[39m \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mstrong_sort/configs/strong_sort.yaml\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;124m'\u001b[39m\u001b[38;5;124mr\u001b[39m\u001b[38;5;124m'\u001b[39m) \u001b[38;5;28;01mas\u001b[39;00m f:\n\u001b[1;32m     13\u001b[0m         cfg \u001b[38;5;241m=\u001b[39m yaml\u001b[38;5;241m.\u001b[39mload(f\u001b[38;5;241m.\u001b[39mread(), Loader\u001b[38;5;241m=\u001b[39myaml\u001b[38;5;241m.\u001b[39mFullLoader)\n\u001b[0;32m---> 15\u001b[0m     strongsort \u001b[38;5;241m=\u001b[39m \u001b[43mStrongSORT\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     16\u001b[0m \u001b[43m        \u001b[49m\u001b[43mappearance_descriptor_weights\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     17\u001b[0m \u001b[43m        \u001b[49m\u001b[43mdevice\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     18\u001b[0m \u001b[43m        \u001b[49m\u001b[43mhalf\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     19\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmax_dist\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcfg\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mSTRONGSORT\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mMAX_DIST\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     20\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmax_iou_distance\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcfg\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mSTRONGSORT\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mMAX_IOU_DISTANCE\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     21\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmax_age\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcfg\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mSTRONGSORT\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mMAX_AGE\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     22\u001b[0m \u001b[43m        \u001b[49m\u001b[43mn_init\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcfg\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mSTRONGSORT\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mN_INIT\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     23\u001b[0m \u001b[43m        \u001b[49m\u001b[43mnn_budget\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcfg\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mSTRONGSORT\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mNN_BUDGET\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     24\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmc_lambda\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcfg\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mSTRONGSORT\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mMC_LAMBDA\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     25\u001b[0m \u001b[43m        \u001b[49m\u001b[43mema_alpha\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcfg\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mSTRONGSORT\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[38;5;124;43mEMA_ALPHA\u001b[39;49m\u001b[38;5;124;43m'\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     26\u001b[0m \n\u001b[1;32m     27\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     28\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m strongsort\n\u001b[1;32m     29\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/modules/yolo_tracker/trackers/strong_sort/strong_sort.py:30\u001b[0m, in \u001b[0;36mStrongSORT.__init__\u001b[0;34m(self, model_weights, device, fp16, max_dist, max_iou_distance, max_age, n_init, nn_budget, mc_lambda, ema_alpha)\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, \n\u001b[1;32m     19\u001b[0m              model_weights,\n\u001b[1;32m     20\u001b[0m              device,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     27\u001b[0m              ema_alpha\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m0.9\u001b[39m\n\u001b[1;32m     28\u001b[0m             ):\n\u001b[0;32m---> 30\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmodel \u001b[38;5;241m=\u001b[39m \u001b[43mReIDDetectMultiBackend\u001b[49m\u001b[43m(\u001b[49m\u001b[43mweights\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmodel_weights\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdevice\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdevice\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mfp16\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mfp16\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     32\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmax_dist \u001b[38;5;241m=\u001b[39m max_dist\n\u001b[1;32m     33\u001b[0m     metric \u001b[38;5;241m=\u001b[39m NearestNeighborDistanceMetric(\n\u001b[1;32m     34\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mcosine\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mmax_dist, nn_budget)\n",
+      "File \u001b[0;32m~/spatialyze-official/spatialyze/video_processor/modules/yolo_tracker/trackers/strong_sort/reid_multibackend.py:58\u001b[0m, in \u001b[0;36mReIDDetectMultiBackend.__init__\u001b[0;34m(self, weights, device, fp16)\u001b[0m\n\u001b[1;32m     56\u001b[0m model_url \u001b[38;5;241m=\u001b[39m get_model_url(w)\n\u001b[1;32m     57\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m file_exists(w) \u001b[38;5;129;01mand\u001b[39;00m model_url \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m---> 58\u001b[0m     \u001b[43mgdown\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdownload\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmodel_url\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;28;43mstr\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43mw\u001b[49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mquiet\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m)\u001b[49m\n\u001b[1;32m     59\u001b[0m \u001b[38;5;28;01melif\u001b[39;00m file_exists(w):\n\u001b[1;32m     60\u001b[0m     \u001b[38;5;28;01mpass\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/spatialyze/lib/python3.10/site-packages/gdown/download.py:259\u001b[0m, in \u001b[0;36mdownload\u001b[0;34m(url, output, quiet, proxy, speed, use_cookies, verify, id, fuzzy, resume, format)\u001b[0m\n\u001b[1;32m    255\u001b[0m     content_disposition \u001b[38;5;241m=\u001b[39m six\u001b[38;5;241m.\u001b[39mmoves\u001b[38;5;241m.\u001b[39murllib_parse\u001b[38;5;241m.\u001b[39munquote(\n\u001b[1;32m    256\u001b[0m         res\u001b[38;5;241m.\u001b[39mheaders[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mContent-Disposition\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[1;32m    257\u001b[0m     )\n\u001b[1;32m    258\u001b[0m     m \u001b[38;5;241m=\u001b[39m re\u001b[38;5;241m.\u001b[39msearch(\u001b[38;5;124mr\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfilename\u001b[39m\u001b[38;5;124m\\\u001b[39m\u001b[38;5;124m*=UTF-8\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124m(.*)\u001b[39m\u001b[38;5;124m\"\u001b[39m, content_disposition)\n\u001b[0;32m--> 259\u001b[0m     filename_from_url \u001b[38;5;241m=\u001b[39m \u001b[43mm\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mgroups\u001b[49m()[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    260\u001b[0m     filename_from_url \u001b[38;5;241m=\u001b[39m filename_from_url\u001b[38;5;241m.\u001b[39mreplace(osp\u001b[38;5;241m.\u001b[39msep, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m_\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[1;32m    261\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'NoneType' object has no attribute 'groups'"
+     ]
+    }
+   ],
+   "source": [
+    "world.saveVideos(os.path.join(OUTPUT_DIR, 'figure12'), addBoundingBoxes=True)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I have added queries for both the Scenic and Skyquery papers.

I think the main things we can try to add is how to splice up images into a matrix and sum across each individual cells in order to predict within the image. One way to do this using the PIL (Python Imaging Library). We would also need a way to create the points and place them ahead of other world.object() to facilitate some of the queries as well which can be created using more helper methods in world.